### PR TITLE
Update BME280Demo.py

### DIFF
--- a/BME280/examples/BME280Demo.py
+++ b/BME280/examples/BME280Demo.py
@@ -1,4 +1,5 @@
-from machine import Pin
+from machine import Pin, I2C
+import time
 import BME280
 i2c = I2C(scl=Pin(22),sda=Pin(21), freq=10000)
 bme = BME280.BME280(i2c=i2c)


### PR DESCRIPTION
import statements for I2C and time where missing, al least I needed them to get the example work on a esp8266 with micro python 1.9.3